### PR TITLE
Pre-decrement the divisors in facdiv

### DIFF
--- a/bench/facdiv/crate-facdiv-rs/src/main.rs
+++ b/bench/facdiv/crate-facdiv-rs/src/main.rs
@@ -16,10 +16,12 @@ fn main() {
         c = &c + &one;
     }
 
+    print!("{:x} ", f);
+
     let mut i = TARGET - 1;
     while i != 0 {
-        f = &f / &c;
         c = &c - &one;
+        f = &f / &c;
         i -= 1;
     }
 

--- a/bench/facdiv/facdiv-py
+++ b/bench/facdiv/facdiv-py
@@ -6,9 +6,12 @@ def main():
     f = 1
     c = 1
 
-    while c < target:
+    while c <= target:
         f *= c
         c += 1
+
+    s = hex(f)[2:]
+    print(s, end=' ')
 
     while c != 1:
         c -= 1

--- a/bench/facdiv/facdiv.c
+++ b/bench/facdiv/facdiv.c
@@ -17,12 +17,14 @@ int main(void)
         mpz_add(c, c, one);
     }
 
+    gmp_printf("%Zx ", f);
+
     mpz_t r;
     mpz_init(r);
 
     for (int i = target - 1; i != 0; --i) {
-        mpz_fdiv_qr(f, r, f, c);
         mpz_sub(c, c, one);
+        mpz_fdiv_qr(f, r, f, c);
     }
 
     gmp_printf("%Zx", f);

--- a/bench/facdiv/facdiv.go
+++ b/bench/facdiv/facdiv.go
@@ -21,11 +21,13 @@ func main() {
 		c.Add(c, one)
 	}
 
+	fmt.Printf("%x ", f)
+
 	r := new(big.Int)
 
 	for i := target - 1; i != 0; i-- {
-		f.QuoRem(f, c, r)
 		c.Sub(c, one)
+		f.QuoRem(f, c, r)
 	}
 
 	fmt.Printf("%x", f)

--- a/bench/facdiv/facdiv.zig
+++ b/bench/facdiv/facdiv.zig
@@ -17,12 +17,16 @@ pub fn main() !void {
         try c.add(&c, &one);
     }
 
+    const ss1 = try f.toString(allocator, 16);
+    try stdout_file.write(ss1);
+    try stdout_file.write(" ");
+
     var r = try BigInt.init(allocator);
 
     i = target - 1;
     while (i != 0) : (i -= 1) {
-        try f.div(&r, &f, &c);
         try c.sub(&c, &one);
+        try f.div(&r, &f, &c);
     }
 
     const ss = try f.toString(allocator, 16);


### PR DESCRIPTION
Since the value `c` was post-incremented while building the factorial
value, it needs to be pre-decremented when dividing it down.  All of
the implementations except Python were printing `0`, because they
started their division with the value 20001.

However, the Python implementation was also missing the final factor of
20000, because it only multiplied `while c < target`.  This has also
been corrected, and all implementations now also print their factorial
value to make sure they're the same.

(None of this makes much difference to the benchmark numbers though.)